### PR TITLE
Fix broken docker run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ docker run -d \
     -p 8222:8222/tcp \
     -p 19132:19132/tcp \
     -p 19132:19132/udp \
-    -p 19132:19133/tcp \
-    -p 19132:19133/udp \
+    -p 19133:19133/tcp \
+    -p 19133:19133/udp \
     -v /apps/docker/minecraftbedrockserver:/config \
     -v /etc/localtime:/etc/localtime:ro \
     -e CREATE_BACKUP_HOURS=12 \


### PR DESCRIPTION
When using the example `docker run` command, it would fail due to trying to map host port 19132 to container ports 19132 and 19133. Update the command to map host port 19132 to container port 19132 and host port 19133 to container port 19133. 